### PR TITLE
Add support for local sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ build/
 dist/
 htmlcov/
 pip-wheel-metadata/
+# Used by github codespaces
+pythonenv*/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,10 @@
   "python.linting.pylintEnabled": false,
   "python.pythonPath": "${workspaceFolder}/.venv",
   "yaml.format.enable": true,
+  "python.testing.pytestArgs": [
+    "."
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.nosetestsEnabled": false,
+  "python.testing.pytestEnabled": true,
 }

--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -12,7 +12,9 @@ from functools import total_ordering
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, TypeVar, Union, NamedTuple
 
-_VERSION_PATTERN = r"^v(?P<base>\d+\.\d+\.\d+)(-?((?P<stage>[a-zA-Z]+)\.?(?P<revision>\d+)?))?(\+(?P<local>.+))?$"
+_VERSION_PATTERN = (
+    r"^v(?P<base>\d+\.\d+\.\d+)(-?((?P<stage>[a-zA-Z]+)\.?(?P<revision>\d+)?))?(\+(?P<local>.+))?$"
+)
 # PEP 440: [N!]N(.N)*[{a|b|rc}N][.postN][.devN][+<local version label>]
 _VALID_PEP440 = r"^(\d!)?\d+(\.\d+)*((a|b|rc)\d+)?(\.post\d+)?(\.dev\d+)?(\+.+)?$"
 _VALID_SEMVER = (
@@ -67,7 +69,7 @@ _match_version_pattern_res = NamedTuple(
         ("stage_revision", Optional[Tuple[str, Optional[int]]]),
         ("newer_tags", Sequence[str]),
         ("local", Optional[str]),
-    ]
+    ],
 )
 
 

--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -12,9 +12,13 @@ from functools import total_ordering
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, TypeVar, Union, NamedTuple
 
-_VERSION_PATTERN = (
-    r"^v(?P<base>\d+\.\d+\.\d+)(-?((?P<stage>[a-zA-Z]+)\.?(?P<revision>\d+)?))?(\+(?P<local>.+))?$"
-)
+_VERSION_PATTERN = r"""
+    (?x)                                                (?# ignore whitespace)
+    ^v(?P<base>\d+\.\d+\.\d+)                           (?# v1.2.3)
+    (-?((?P<stage>[a-zA-Z]+)\.?(?P<revision>\d+)?))?    (?# b0)
+    (\+(?P<tagged_metadata>.+))?$                       (?# +linux)
+    """
+
 # PEP 440: [N!]N(.N)*[{a|b|rc}N][.postN][.devN][+<local version label>]
 _VALID_PEP440 = r"^(\d!)?\d+(\.\d+)*((a|b|rc)\d+)?(\.post\d+)?(\.dev\d+)?(\+.+)?$"
 _VALID_SEMVER = (
@@ -68,7 +72,7 @@ _match_version_pattern_res = NamedTuple(
         ("base", str),
         ("stage_revision", Optional[Tuple[str, Optional[int]]]),
         ("newer_tags", Sequence[str]),
-        ("local", Optional[str]),
+        ("tagged_metadata", Optional[str]),
     ],
 )
 
@@ -84,13 +88,13 @@ def _match_version_pattern(
           * stage
           * revision
         * any newer unmatched tags
-        * local matched section
+        * tagged_metadata matched section
     """
     pattern_match = None
     base = None
     stage_revision = None
     newer_unmatched_tags = []
-    local = None
+    tagged_metadata = None
 
     for source in sources[:1] if latest_source else sources:
         pattern_match = re.search(pattern, source)
@@ -118,13 +122,13 @@ def _match_version_pattern(
     try:
         stage = pattern_match.group("stage")
         revision = pattern_match.group("revision")
-        local = pattern_match.group("local")
+        tagged_metadata = pattern_match.group("tagged_metadata")
         if stage is not None:
             stage_revision = (stage, None) if revision is None else (stage, int(revision))
     except IndexError:
         pass
 
-    return _match_version_pattern_res(source, base, stage_revision, newer_unmatched_tags, local)
+    return _match_version_pattern_res(source, base, stage_revision, newer_unmatched_tags, tagged_metadata)
 
 
 def _blank(value: Optional[_T], default: _T) -> _T:
@@ -173,7 +177,7 @@ class Version:
         distance: int = 0,
         commit: str = None,
         dirty: bool = None,
-        local: Optional[str] = None
+        tagged_metadata: Optional[str] = None
     ) -> None:
         """
         :param base: Release segment, such as 0.1.0.
@@ -197,8 +201,8 @@ class Version:
         self.commit = commit
         #: Whether there are uncommitted changes.
         self.dirty = dirty
-        #: The version contains baked in local metadata
-        self.local = local
+        #: The version contains baked in tagged_metadata metadata
+        self.tagged_metadata = tagged_metadata
 
         self._matched_tag = None  # type: Optional[str]
         self._newer_unmatched_tags = None  # type: Optional[Sequence[str]]
@@ -247,12 +251,13 @@ class Version:
         format: str = None,
         style: Style = None,
         bump: bool = False,
+        tagged_metadata: bool = False,
     ) -> str:
         """
         Create a string from the version info.
 
         :param metadata: Metadata (commit, dirty) is normally included in
-            the local version part if post or dev are set. Set this to True to
+            the tagged_metadata version part if post or dev are set. Set this to True to
             always include metadata, or set it to False to always exclude it.
         :param dirty: Set this to True to include a dirty flag in the
             metadata if applicable. Inert when metadata=False.
@@ -264,6 +269,7 @@ class Version:
             * {revision}
             * {distance}
             * {commit}
+            * {tagged_metadata}
             * {dirty} which expands to either "dirty" or "clean"
         :param style: Built-in output formats. Will default to PEP 440 if not
             set and no custom format given. If you specify both a style and a
@@ -272,6 +278,8 @@ class Version:
         :param bump: If true, increment the last part of the `base` by 1,
             unless `stage` is set, in which case either increment `revision`
             by 1 or set it to a default of 2 if there was no revision.
+        :param tagged_metadata: If true use the tagged_metadata in the version as the first
+            segment of metadata.
         """
         base = self.base
         revision = self.revision
@@ -291,6 +299,7 @@ class Version:
                 revision=_blank(revision, ""),
                 distance=_blank(self.distance, ""),
                 commit=_blank(self.commit, ""),
+                tagged_metadata=_blank(self.tagged_metadata, ""),
                 dirty="dirty" if self.dirty else "clean",
             )
             if style is not None:
@@ -301,12 +310,11 @@ class Version:
             style = Style.Pep440
         out = ""
 
-        # treat local segments as the first meta_part
-        if self.local:
-            meta_parts = [self.local]
-        else:
-            meta_parts = []
+        meta_parts = []
         if metadata is not False:
+            # treat tagged_metadata segments as the first meta_part
+            if tagged_metadata and self.tagged_metadata:
+                meta_parts.append(self.tagged_metadata)
             if (metadata or self.distance > 0) and self.commit is not None:
                 meta_parts.append(self.commit)
             if dirty and self.dirty:
@@ -398,12 +406,12 @@ class Version:
             t[0]
             for t in reversed(sorted(detailed_tags, key=lambda x: x[1] if x[2] is None else x[2]))
         ]
-        tag, base, stage, unmatched, local = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
 
         code, msg = _run_cmd("git rev-list --count refs/tags/{}..HEAD".format(tag))
         distance = int(msg)
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, local=local)
+        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -444,13 +452,13 @@ class Version:
                 distance = 0
             return cls("0.0.0", distance=distance, commit=commit, dirty=dirty)
         tags = [tag for tags in [line.split(":") for line in msg.splitlines()] for tag in tags]
-        tag, base, stage, unmatched, local = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
 
         code, msg = _run_cmd('hg log -r "{0}::{1} - {0}" --template "."'.format(tag, commit))
         # The tag itself is in the list, so offset by 1.
         distance = max(len(msg) - 1, 0)
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, local=local)
+        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -487,13 +495,13 @@ class Version:
                 distance = 0
             return cls("0.0.0", distance=distance, commit=commit, dirty=dirty)
         tags = msg.splitlines()
-        tag, base, stage, unmatched, local = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
 
         code, msg = _run_cmd("darcs log --from-tag {} --count".format(tag))
         # The tag itself is in the list, so offset by 1.
         distance = int(msg) - 1
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, local=local)
+        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -552,13 +560,13 @@ class Version:
                     source = int(match.group(1))
                     tags_to_sources_revs[tag] = (source, rev)
         tags = sorted(tags_to_sources_revs, key=lambda x: tags_to_sources_revs[x], reverse=True)
-        tag, base, stage, unmatched, local = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
 
         source, rev = tags_to_sources_revs[tag]
         # The tag itself is in the list, so offset by 1.
         distance = int(commit) - 1 - source
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, local=local)
+        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -599,11 +607,11 @@ class Version:
             if line.split()[1] != "?"
         }
         tags = [x[1] for x in sorted([(v, k) for k, v in tags_to_revs.items()], reverse=True)]
-        tag, base, stage, unmatched, local = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
 
         distance = int(commit) - tags_to_revs[tag]
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, local=local)
+        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -675,12 +683,12 @@ class Version:
             (line.rsplit(",", 1)[0][5:-1], int(line.rsplit(",", 1)[1]) - 1)
             for line in msg.splitlines()
         ]
-        tag, base, stage, unmatched, local = _match_version_pattern(
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(
             pattern, [t for t, d in tags_to_distance], latest_tag
         )
         distance = dict(tags_to_distance)[tag]
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, local=local)
+        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version

--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -128,7 +128,9 @@ def _match_version_pattern(
     except IndexError:
         pass
 
-    return _match_version_pattern_res(source, base, stage_revision, newer_unmatched_tags, tagged_metadata)
+    return _match_version_pattern_res(
+        source, base, stage_revision, newer_unmatched_tags, tagged_metadata
+    )
 
 
 def _blank(value: Optional[_T], default: _T) -> _T:
@@ -406,12 +408,21 @@ class Version:
             t[0]
             for t in reversed(sorted(detailed_tags, key=lambda x: x[1] if x[2] is None else x[2]))
         ]
-        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(
+            pattern, tags, latest_tag
+        )
 
         code, msg = _run_cmd("git rev-list --count refs/tags/{}..HEAD".format(tag))
         distance = int(msg)
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
+        version = cls(
+            base,
+            stage=stage,
+            distance=distance,
+            commit=commit,
+            dirty=dirty,
+            tagged_metadata=tagged_metadata,
+        )
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -452,13 +463,22 @@ class Version:
                 distance = 0
             return cls("0.0.0", distance=distance, commit=commit, dirty=dirty)
         tags = [tag for tags in [line.split(":") for line in msg.splitlines()] for tag in tags]
-        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(
+            pattern, tags, latest_tag
+        )
 
         code, msg = _run_cmd('hg log -r "{0}::{1} - {0}" --template "."'.format(tag, commit))
         # The tag itself is in the list, so offset by 1.
         distance = max(len(msg) - 1, 0)
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
+        version = cls(
+            base,
+            stage=stage,
+            distance=distance,
+            commit=commit,
+            dirty=dirty,
+            tagged_metadata=tagged_metadata,
+        )
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -495,13 +515,22 @@ class Version:
                 distance = 0
             return cls("0.0.0", distance=distance, commit=commit, dirty=dirty)
         tags = msg.splitlines()
-        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(
+            pattern, tags, latest_tag
+        )
 
         code, msg = _run_cmd("darcs log --from-tag {} --count".format(tag))
         # The tag itself is in the list, so offset by 1.
         distance = int(msg) - 1
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
+        version = cls(
+            base,
+            stage=stage,
+            distance=distance,
+            commit=commit,
+            dirty=dirty,
+            tagged_metadata=tagged_metadata,
+        )
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -560,13 +589,22 @@ class Version:
                     source = int(match.group(1))
                     tags_to_sources_revs[tag] = (source, rev)
         tags = sorted(tags_to_sources_revs, key=lambda x: tags_to_sources_revs[x], reverse=True)
-        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(
+            pattern, tags, latest_tag
+        )
 
         source, rev = tags_to_sources_revs[tag]
         # The tag itself is in the list, so offset by 1.
         distance = int(commit) - 1 - source
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
+        version = cls(
+            base,
+            stage=stage,
+            distance=distance,
+            commit=commit,
+            dirty=dirty,
+            tagged_metadata=tagged_metadata,
+        )
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -607,11 +645,20 @@ class Version:
             if line.split()[1] != "?"
         }
         tags = [x[1] for x in sorted([(v, k) for k, v in tags_to_revs.items()], reverse=True)]
-        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(pattern, tags, latest_tag)
+        tag, base, stage, unmatched, tagged_metadata = _match_version_pattern(
+            pattern, tags, latest_tag
+        )
 
         distance = int(commit) - tags_to_revs[tag]
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
+        version = cls(
+            base,
+            stage=stage,
+            distance=distance,
+            commit=commit,
+            dirty=dirty,
+            tagged_metadata=tagged_metadata,
+        )
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version
@@ -688,7 +735,14 @@ class Version:
         )
         distance = dict(tags_to_distance)[tag]
 
-        version = cls(base, stage=stage, distance=distance, commit=commit, dirty=dirty, tagged_metadata=tagged_metadata)
+        version = cls(
+            base,
+            stage=stage,
+            distance=distance,
+            commit=commit,
+            dirty=dirty,
+            tagged_metadata=tagged_metadata,
+        )
         version._matched_tag = tag
         version._newer_unmatched_tags = unmatched
         return version

--- a/dunamai/__main__.py
+++ b/dunamai/__main__.py
@@ -27,6 +27,12 @@ common_sub_args = [
         "help": "Include dirty flag if applicable",
     },
     {
+        "triggers": ["--tagged-metadata"],
+        "action": "store_true",
+        "dest": "tagged_metadata",
+        "help": "Include tagged metadata if applicable",
+    },
+    {
         "triggers": ["--pattern"],
         "default": _VERSION_PATTERN,
         "help": (
@@ -202,9 +208,10 @@ def from_vcs(
     tag_dir: str,
     debug: bool,
     bump: bool,
+    tagged_metadata: bool,
 ) -> None:
     version = Version.from_vcs(vcs, pattern, latest_tag, tag_dir)
-    print(version.serialize(metadata, dirty, format, style, bump))
+    print(version.serialize(metadata, dirty, format, style, bump, tagged_metadata=tagged_metadata))
     if debug:
         print("# Matched tag: {}".format(version._matched_tag), file=sys.stderr)
         print("# Newer unmatched tags: {}".format(version._newer_unmatched_tags), file=sys.stderr)
@@ -226,6 +233,7 @@ def main() -> None:
                 tag_dir,
                 args.debug,
                 args.bump,
+                args.tagged_metadata,
             )
         elif args.command == "check":
             version = from_stdin(args.version)

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -271,9 +271,8 @@ def test__version__serialize__pep440_metadata() -> None:
         Version("0.1.0", distance=1, commit="abc").serialize(metadata=False) == "0.1.0.post1.dev0"
     )
 
-    assert (
-        Version("0.1.0", distance=1, commit="abc", local="def").serialize(metadata=False) == "0.1.0.post1.dev0+def"
-    )
+    serialized = Version("0.1.0", distance=1, commit="abc", local="def").serialize(metadata=False)
+    assert serialized == "0.1.0.post1.dev0+def"
 
 
 def test__version__serialize__semver_with_metadata() -> None:
@@ -495,7 +494,9 @@ def test__check_version__pvp() -> None:
 
 
 def test__default_version_pattern() -> None:
-    def check_re(tag: str, base: str = None, stage: str = None, revision: str = None, local: str = None) -> None:
+    def check_re(
+        tag: str, base: str = None, stage: str = None, revision: str = None, local: str = None
+    ) -> None:
         result = re.search(_VERSION_PATTERN, tag)
         if result is None:
             if any(x is not None for x in [base, stage, revision]):

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -496,12 +496,16 @@ def test__check_version__pvp() -> None:
 
 def test__default_version_pattern() -> None:
     def check_re(
-        tag: str, base: str = None, stage: str = None, revision: str = None, tagged_metadata: str = None
+        tag: str,
+        base: str = None,
+        stage: str = None,
+        revision: str = None,
+        tagged_metadata: str = None,
     ) -> None:
         result = re.search(_VERSION_PATTERN, tag)
         if result is None:
             if any(x is not None for x in [base, stage, revision]):
-                raise ValueError(f"Pattern did not match, {tag}")
+                raise ValueError("Pattern did not match, {tag}".format(tag=tag))
         else:
             assert result.group("base") == base
             assert result.group("stage") == stage

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -56,13 +56,14 @@ from_explicit_vcs = make_from_callback(Version.from_vcs)
 
 
 def test__version__init() -> None:
-    v = Version("1", stage=("a", 2), distance=3, commit="abc", dirty=True)
+    v = Version("1", stage=("a", 2), distance=3, commit="abc", dirty=True, local="def")
     assert v.base == "1"
     assert v.stage == "a"
     assert v.revision == 2
     assert v.distance == 3
     assert v.commit == "abc"
     assert v.dirty
+    assert v.local == "def"
 
 
 def test__version__str() -> None:
@@ -268,6 +269,10 @@ def test__version__serialize__pep440_metadata() -> None:
     )
     assert (
         Version("0.1.0", distance=1, commit="abc").serialize(metadata=False) == "0.1.0.post1.dev0"
+    )
+
+    assert (
+        Version("0.1.0", distance=1, commit="abc", local="def").serialize(metadata=False) == "0.1.0.post1.dev0+def"
     )
 
 
@@ -490,7 +495,7 @@ def test__check_version__pvp() -> None:
 
 
 def test__default_version_pattern() -> None:
-    def check_re(tag: str, base: str = None, stage: str = None, revision: str = None) -> None:
+    def check_re(tag: str, base: str = None, stage: str = None, revision: str = None, local: str = None) -> None:
         result = re.search(_VERSION_PATTERN, tag)
         if result is None:
             if any(x is not None for x in [base, stage, revision]):
@@ -499,6 +504,7 @@ def test__default_version_pattern() -> None:
             assert result.group("base") == base
             assert result.group("stage") == stage
             assert result.group("revision") == revision
+            assert result.group("local") == local
 
     check_re("v0.1.0", "0.1.0")
     check_re("av0.1.0")
@@ -514,6 +520,8 @@ def test__default_version_pattern() -> None:
 
     check_re("v0.1.0rc.4", "0.1.0", "rc", "4")
     check_re("v0.1.0-beta", "0.1.0", "beta")
+
+    check_re("v0.1.0rc.4+specifier", "0.1.0", "rc", "4", local="specifier")
 
 
 def test__serialize_pep440():

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -56,14 +56,14 @@ from_explicit_vcs = make_from_callback(Version.from_vcs)
 
 
 def test__version__init() -> None:
-    v = Version("1", stage=("a", 2), distance=3, commit="abc", dirty=True, local="def")
+    v = Version("1", stage=("a", 2), distance=3, commit="abc", dirty=True, tagged_metadata="def")
     assert v.base == "1"
     assert v.stage == "a"
     assert v.revision == 2
     assert v.distance == 3
     assert v.commit == "abc"
     assert v.dirty
-    assert v.local == "def"
+    assert v.tagged_metadata == "def"
 
 
 def test__version__str() -> None:
@@ -271,8 +271,9 @@ def test__version__serialize__pep440_metadata() -> None:
         Version("0.1.0", distance=1, commit="abc").serialize(metadata=False) == "0.1.0.post1.dev0"
     )
 
-    serialized = Version("0.1.0", distance=1, commit="abc", local="def").serialize(metadata=False)
-    assert serialized == "0.1.0.post1.dev0+def"
+    v = Version("0.1.0", distance=1, commit="abc", tagged_metadata="def")
+    serialized = v.serialize(tagged_metadata=True)
+    assert serialized == "0.1.0.post1.dev0+def.abc"
 
 
 def test__version__serialize__semver_with_metadata() -> None:
@@ -495,17 +496,17 @@ def test__check_version__pvp() -> None:
 
 def test__default_version_pattern() -> None:
     def check_re(
-        tag: str, base: str = None, stage: str = None, revision: str = None, local: str = None
+        tag: str, base: str = None, stage: str = None, revision: str = None, tagged_metadata: str = None
     ) -> None:
         result = re.search(_VERSION_PATTERN, tag)
         if result is None:
             if any(x is not None for x in [base, stage, revision]):
-                raise ValueError("Pattern did not match")
+                raise ValueError(f"Pattern did not match, {tag}")
         else:
             assert result.group("base") == base
             assert result.group("stage") == stage
             assert result.group("revision") == revision
-            assert result.group("local") == local
+            assert result.group("tagged_metadata") == tagged_metadata
 
     check_re("v0.1.0", "0.1.0")
     check_re("av0.1.0")
@@ -522,7 +523,7 @@ def test__default_version_pattern() -> None:
     check_re("v0.1.0rc.4", "0.1.0", "rc", "4")
     check_re("v0.1.0-beta", "0.1.0", "beta")
 
-    check_re("v0.1.0rc.4+specifier", "0.1.0", "rc", "4", local="specifier")
+    check_re("v0.1.0rc.4+specifier", "0.1.0", "rc", "4", tagged_metadata="specifier")
 
 
 def test__serialize_pep440():

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -19,6 +19,7 @@ def test__parse_args__from():
         tag_dir="tags",
         debug=False,
         bump=False,
+        tagged_metadata=False,
     )
     assert parse_args(["from", "git"]).vcs == "git"
     assert parse_args(["from", "mercurial"]).vcs == "mercurial"
@@ -37,6 +38,7 @@ def test__parse_args__from():
     assert parse_args(["from", "any", "--latest-tag"]).latest_tag is True
     assert parse_args(["from", "any", "--tag-dir", "foo"]).tag_dir == "foo"
     assert parse_args(["from", "any", "--debug"]).debug is True
+    assert parse_args(["from", "any", "--tagged-metadata"]).tagged_metadata is True
     assert parse_args(["from", "subversion", "--tag-dir", "foo"]).tag_dir == "foo"
 
     with pytest.raises(SystemExit):


### PR DESCRIPTION
This will correctly deal with pep440 version strings of the form X.Y+local. (as per https://www.python.org/dev/peps/pep-0440/#local-version-identifiers)

The plan is to add the additional support into tools that make use of this such as poetry-dynamic-versioning