### PR TITLE
Added a more aggressive sorting mechanism for git tags

### DIFF
--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -446,7 +446,7 @@ class Version:
 
             @property
             def commit_offset(self):
-                return tag_topo_lookup[self.commit, self.fullref]
+                return tag_topo_lookup[self.fullref]
 
             @property
             def sort_key(self):
@@ -460,11 +460,7 @@ class Version:
 
         for line in msg.strip().splitlines():
             parts = line.split("@{")
-            detailed_tags.append(
-                GitRefInfo(
-                    *parts,
-                )
-            )
+            detailed_tags.append(GitRefInfo(*parts))
 
         detailed_tags.sort(key=lambda t: t.sort_key)
         detailed_tags.reverse()
@@ -489,7 +485,7 @@ class Version:
         return version
 
     @classmethod
-    def _from_git_tag_topo_order(cls) -> Mapping[Tuple[str, str], int]:
+    def _from_git_tag_topo_order(cls) -> Mapping[str, int]:
         """"""
         code, logmsg = _run_cmd(
             dedent(
@@ -507,7 +503,7 @@ class Version:
         tag_lookup = {}
         for tag_offset, line in enumerate(logmsg.strip().splitlines(keepends=False)):
             # lines have the pattern
-            # <gitsha>  (tag: refs/tags/v1.2.0b1, tag: refs/tags/v1.2.0)
+            # <gitsha1>  (tag: refs/tags/v1.2.0b1, tag: refs/tags/v1.2.0)
             commit, _, tags = line.partition("(")
             commit = commit.strip()
             if tags:
@@ -518,7 +514,7 @@ class Version:
                 ]
                 taglist = [tag.split()[-1] for tag in taglist]
                 for tag in taglist:
-                    tag_lookup[commit, tag] = tag_offset
+                    tag_lookup[tag] = tag_offset
         return tag_lookup
 
     @classmethod

--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -446,7 +446,11 @@ class Version:
 
             @property
             def commit_offset(self):
-                return tag_topo_lookup[self.fullref]
+                try:
+                    return tag_topo_lookup[self.fullref]
+                except KeyError:
+                    print(tag_topo_lookup)
+                    raise
 
             @property
             def sort_key(self):

--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -505,6 +505,14 @@ class Version:
             )
         )
         tag_lookup = {}
+
+        def noralize_tag_ref(tagref: str) -> str:
+            """Older versions of git do not correctly respect --decorate-refs"""
+            if tagref.startswith("refs/tags/"):
+                return tagref
+            else:
+                return "refs/tags/{}".format(tagref)
+
         for tag_offset, line in enumerate(logmsg.strip().splitlines(keepends=False)):
             # lines have the pattern
             # <gitsha1>  (tag: refs/tags/v1.2.0b1, tag: refs/tags/v1.2.0)
@@ -517,6 +525,7 @@ class Version:
                     tag.strip() for tag in tags.split(",") if tag.strip().startswith("tag: ")
                 ]
                 taglist = [tag.split()[-1] for tag in taglist]
+                taglist = [noralize_tag_ref(tag) for tag in taglist]
                 for tag in taglist:
                     tag_lookup[tag] = tag_offset
         return tag_lookup

--- a/tests/integration/test_dunamai.py
+++ b/tests/integration/test_dunamai.py
@@ -113,6 +113,9 @@ def test__version__from_git__with_annotated_tags(tmp_path) -> None:
         with pytest.raises(ValueError):
             from_vcs(latest_tag=True)
 
+        # check that we find the expected tag that has the most recent tag creation time
+        avoid_identical_ref_timestamps()
+        run("git tag v0.2.0b1 -m Annotated")
         avoid_identical_ref_timestamps()
         run("git tag v0.2.0 -m Annotated")
         avoid_identical_ref_timestamps()


### PR DESCRIPTION
This should ensure that tags that are more recent topologically will always take precedence.  Additionally we prefer using the timestamp from the tag (if annotated), which ensures that annotated tags created more recently for the same commit are selected.

This should prevent edge cases arising from multiple timezones being used to commit to the same git repository.