### PR TITLE
call main when executed as python -m dunamai

### DIFF
--- a/dunamai/__main__.py
+++ b/dunamai/__main__.py
@@ -247,5 +247,6 @@ def main() -> None:
         print(e, file=sys.stderr)
         sys.exit(1)
 
+
 if __name__ == "__main__":
     main()

--- a/dunamai/__main__.py
+++ b/dunamai/__main__.py
@@ -246,3 +246,6 @@ def main() -> None:
     except Exception as e:
         print(e, file=sys.stderr)
         sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In some edge-cases `dunamai` might not be executable by itself. This allows to use `python -m dunamai` additionally, which might be helpful in such cases.