### PR TITLE
add ignore option to get_version and add shortcut

### DIFF
--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -993,7 +993,6 @@ def get_version(
     :param fallback: If no other matches found, use this version.
     :param ignore: Ignore this version if it is found.
     """
-
     if isinstance(ignore, str):
         ignore = Version(ignore)
 
@@ -1019,6 +1018,33 @@ def get_version(
             return third_ver
 
     return fallback
+
+
+def get_version_from_vcs(
+    name: str,
+    first_choice: Callable[[], Optional[Version]] = None,
+    third_choice: Callable[[], Optional[Version]] = Version.from_any_vcs,
+    fallback: Version = Version("0.0.0"),
+    ignore: Union[str, Version] = "0",
+) -> Version:
+    """
+    A shortcut call on the `get_version` function with the third choice any vcs.
+
+    Check pkg_resources info or a fallback function to determine the version.
+    This is intended as a convenient default for setting your `__version__` if
+    you do not want to include a generated version statically during packaging.
+
+    :param name: Installed package name.
+    :param first_choice: Callback to determine a version before checking
+        to see if the named package is installed.
+    :param third_choice: Callback to determine a version if the installed
+        package cannot be found by name.
+    :param fallback: If no other matches found, use this version.
+    :param ignore: Ignore this version if it is found.
+    """
+    return get_version(
+        name, first_choice=first_choice, third_choice=third_choice, fallback=fallback, ignore=ignore
+    )
 
 
 def serialize_pep440(

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -444,11 +444,11 @@ def test__get_version__fallback() -> None:
 
 def test__get_version__from_name__ignore() -> None:
     assert get_version(
-        "dunamai", ignore=pkg_resources.get_distribution("dunamai").version, fallback=Version("2")
+        "dunamai", ignore=[pkg_resources.get_distribution("dunamai").version], fallback=Version("2")
     ) == Version("2")
     assert get_version(
         "dunamai",
-        ignore=Version(pkg_resources.get_distribution("dunamai").version),
+        ignore=[Version(pkg_resources.get_distribution("dunamai").version)],
         fallback=Version("2"),
     ) == Version("2")
 
@@ -457,13 +457,13 @@ def test__get_version__first_choice__ignore() -> None:
     assert get_version(
         "dunamai_nonexistent_test",
         first_choice=lambda: Version("1"),
-        ignore="1",
+        ignore=["1"],
         fallback=Version("2"),
     ) == Version("2")
     assert get_version(
         "dunamai_nonexistent_test",
         first_choice=lambda: Version("1"),
-        ignore=Version("1"),
+        ignore=[Version("1")],
         fallback=Version("2"),
     ) == Version("2")
 
@@ -472,13 +472,13 @@ def test__get_version__third_choice__ignore() -> None:
     assert get_version(
         "dunamai_nonexistent_test",
         third_choice=lambda: Version("3"),
-        ignore="3",
+        ignore=["3"],
         fallback=Version("2"),
     ) == Version("2")
     assert get_version(
         "dunamai_nonexistent_test",
         third_choice=lambda: Version("3"),
-        ignore=Version("3"),
+        ignore=[Version("3")],
         fallback=Version("2"),
     ) == Version("2")
 

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -1,5 +1,5 @@
 import os
-import pkg_resources
+import pkg_resources  # type: ignore
 import re
 from contextlib import contextmanager
 from pathlib import Path
@@ -443,44 +443,62 @@ def test__get_version__fallback() -> None:
 
 
 def test__get_version__from_name__ignore() -> None:
-    assert get_version(
-        "dunamai", ignore=[pkg_resources.get_distribution("dunamai").version], fallback=Version("2")
-    ) == Version("2")
-    assert get_version(
-        "dunamai",
-        ignore=[Version(pkg_resources.get_distribution("dunamai").version)],
-        fallback=Version("2"),
-    ) == Version("2")
+    assert (
+        get_version(
+            "dunamai",
+            ignore=[Version(pkg_resources.get_distribution("dunamai").version)],
+            fallback=Version("2"),
+        )
+        == Version("2")
+    )
 
 
 def test__get_version__first_choice__ignore() -> None:
-    assert get_version(
-        "dunamai_nonexistent_test",
-        first_choice=lambda: Version("1"),
-        ignore=["1"],
-        fallback=Version("2"),
-    ) == Version("2")
-    assert get_version(
-        "dunamai_nonexistent_test",
-        first_choice=lambda: Version("1"),
-        ignore=[Version("1")],
-        fallback=Version("2"),
-    ) == Version("2")
+    assert (
+        get_version(
+            "dunamai_nonexistent_test",
+            first_choice=lambda: Version("1"),
+            ignore=[Version("1")],
+            fallback=Version("2"),
+        )
+        == Version("2")
+    )
+
+
+def test__get_version__first_choice__ignore__with_commit() -> None:
+    assert (
+        get_version(
+            "dunamai_nonexistent_test",
+            first_choice=lambda: Version("1", commit="aaaa"),
+            ignore=[Version("1")],
+            fallback=Version("2"),
+        )
+        == Version("2")
+    )
+
+
+def test__get_version__first_choice__ignore__without_commit() -> None:
+    assert (
+        get_version(
+            "dunamai_nonexistent_test",
+            first_choice=lambda: Version("1"),
+            ignore=[Version("1", commit="aaaa")],
+            fallback=Version("2"),
+        )
+        == Version("1")
+    )
 
 
 def test__get_version__third_choice__ignore() -> None:
-    assert get_version(
-        "dunamai_nonexistent_test",
-        third_choice=lambda: Version("3"),
-        ignore=["3"],
-        fallback=Version("2"),
-    ) == Version("2")
-    assert get_version(
-        "dunamai_nonexistent_test",
-        third_choice=lambda: Version("3"),
-        ignore=[Version("3")],
-        fallback=Version("2"),
-    ) == Version("2")
+    assert (
+        get_version(
+            "dunamai_nonexistent_test",
+            third_choice=lambda: Version("3"),
+            ignore=[Version("3")],
+            fallback=Version("2"),
+        )
+        == Version("2")
+    )
 
 
 def test__version__from_any_vcs(tmp_path) -> None:

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -442,6 +442,47 @@ def test__get_version__fallback() -> None:
     assert get_version("dunamai_nonexistent_test") == Version("0.0.0")
 
 
+def test__get_version__from_name__ignore() -> None:
+    assert get_version(
+        "dunamai", ignore=pkg_resources.get_distribution("dunamai").version, fallback=Version("2")
+    ) == Version("2")
+    assert get_version(
+        "dunamai",
+        ignore=Version(pkg_resources.get_distribution("dunamai").version),
+        fallback=Version("2"),
+    ) == Version("2")
+
+
+def test__get_version__first_choice__ignore() -> None:
+    assert get_version(
+        "dunamai_nonexistent_test",
+        first_choice=lambda: Version("1"),
+        ignore="1",
+        fallback=Version("2"),
+    ) == Version("2")
+    assert get_version(
+        "dunamai_nonexistent_test",
+        first_choice=lambda: Version("1"),
+        ignore=Version("1"),
+        fallback=Version("2"),
+    ) == Version("2")
+
+
+def test__get_version__third_choice__ignore() -> None:
+    assert get_version(
+        "dunamai_nonexistent_test",
+        third_choice=lambda: Version("3"),
+        ignore="3",
+        fallback=Version("2"),
+    ) == Version("2")
+    assert get_version(
+        "dunamai_nonexistent_test",
+        third_choice=lambda: Version("3"),
+        ignore=Version("3"),
+        fallback=Version("2"),
+    ) == Version("2")
+
+
 def test__version__from_any_vcs(tmp_path) -> None:
     with chdir(tmp_path):
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
Two proposed edits:

1. Add a ignore option to the `get_version` function
2. Add a shortcut function that uses `Version.from_any_vcs` as third choice