### PR TITLE
Enforce '--no-show-signature' on git-log timestamp retrieval

### DIFF
--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -815,7 +815,7 @@ class Version:
             return cls("0.0.0", distance=0, dirty=True, branch=branch)
         commit = msg
 
-        code, msg = _run_cmd('git log -n 1 --pretty=format:"%cI"')
+        code, msg = _run_cmd('git log --no-show-signature -n 1 --pretty=format:"%cI"')
         timestamp = _parse_git_timestamp_iso_strict(msg)
 
         code, msg = _run_cmd("git describe --always --dirty")


### PR DESCRIPTION
## Context

I've experienced a problem building the [copier](https://github.com/copier-org/copier) project from source using the `poetry build` command.

`copier` uses [poetry-dynamic-versioning](https://github.com/mtkennerly/poetry-dynamic-versioning).

The `poetry build` command fails with the following error:

```
copier on  HEAD (9735f73) [!] 
❯ poetry build

time data "gpg: Signature made Wed Oct 12 14:41:26 2022 CEST\ngpg:                using EDDSA key 83C8FC19286635F94800F1CBE47E3BE44B940490\ngpg: Can't check signature: No public key\n2022-10-12T14:41:21+0200" does not match format '%Y-%m-%dT%H:%M:%S%z'
```

The `git` command that is at the origin of the problem is:

```
copier on  HEAD (9735f73) [!] 
❯ git log -n 1 --pretty=format:"%cI"
gpg: Signature made Wed Oct 12 14:41:26 2022 CEST
gpg:                using EDDSA key 83C8FC19286635F94800F1CBE47E3BE44B940490
gpg: Can't check signature: No public key
2022-10-12T14:41:21+02:00
```

The **gpg** signature headers get in the way of the _timestamp retrieval_ logic.

### My git configuration

This signature is displayed because I do have

```
[log]
  showSignature = true
```

in my `~/.gitconfig` file.

### Can I reproduce with other projects ?

I was able to reproduce the problem with other projects relying on `poetry-dynamic-versioning`.

## Proposed solution

I know that the _root cause_ of the problem is the `showSignature = true` setting in my `~/.gitconfig` file.

But if we enforce the `--no-show-signature` `git-log` flag, we ensures that no _Signature message_ could get in the way of the `git-log timestamp` parsing logic.

```
copier on  HEAD (9735f73) [!] 
❯ git log --no-show-signature -n 1 --pretty=format:"%cI"
2022-10-12T14:41:21+02:00
```
