### PR TITLE
add: bump param in bump_version

### DIFF
--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -1932,7 +1932,7 @@ def serialize_pvp(base: str, metadata: Optional[Sequence[Union[str, int]]] = Non
     return serialized
 
 
-def bump_version(base: str, index: int = -1) -> str:
+def bump_version(base: str, index: int = -1, bump: int = 1) -> str:
     """
     Increment one of the numerical positions of a version.
 
@@ -1942,10 +1942,11 @@ def bump_version(base: str, index: int = -1) -> str:
         This follows Python indexing rules, so positive numbers start from
         the left side and count up from 0, while negative numbers start from
         the right side and count down from -1.
+    :param bump: By how much the index needs to increment. Default: 1.
     :return: Bumped version.
     """
     bases = [int(x) for x in base.split(".")]
-    bases[index] += 1
+    bases[index] += bump
 
     limit = 0 if index < 0 else len(bases)
     i = index + 1

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -816,6 +816,7 @@ def test__serialize_pvp():
 
 
 def test__bump_version():
+    # default bump=1
     assert bump_version("1.2.3") == "1.2.4"
 
     assert bump_version("1.2.3", 0) == "2.0.0"
@@ -825,7 +826,19 @@ def test__bump_version():
     assert bump_version("1.2.3", -1) == "1.2.4"
     assert bump_version("1.2.3", -2) == "1.3.0"
     assert bump_version("1.2.3", -3) == "2.0.0"
+    
+    # expicit bump increment
+    assert bump_version("1.2.3", bump=3) == "1.2.6"
 
+    assert bump_version("1.2.3", 0, bump=3) == "4.0.0"
+    assert bump_version("1.2.3", 1, bump=3) == "1.5.0"
+    assert bump_version("1.2.3", 2, bump=3) == "1.2.6"
+
+    assert bump_version("1.2.3", -1, bump=3) == "1.2.6"
+    assert bump_version("1.2.3", -2, bump=3) == "1.5.0"
+    assert bump_version("1.2.3", -3, bump=3) == "4.0.0"
+    
+    # check if incorrect index raises issues
     with pytest.raises(IndexError):
         bump_version("1.2.3", 3)
 


### PR DESCRIPTION
Allows you to handle advanced cases where you want to explicitly mention how much we like to increase the version. Useful in semver where the last index is the patch number and needs to be increased by distance.