### PR TITLE
Support getting versions from out of tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ htmlcov/
 pip-wheel-metadata/
 # Used by github codespaces
 pythonenv*/
+*.swp

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -865,9 +865,7 @@ def test__bump_version():
 def test__get_version_outside_repo():
     # TODO: Test vcs other than git
     with tempfile.TemporaryDirectory() as dirname:
-        # Initialize a git repo
         Repo.init(dirname)
-        # os.chdir(dirname)
         os.chdir("/")
 
         def make_from(func):
@@ -875,5 +873,5 @@ def test__get_version_outside_repo():
                 return func(*args, path=dirname, **kwargs)
             return from_other
 
-        print(get_version('placeholder', third_choice=make_from(Version.from_git)))
-        print(get_version('placeholder', third_choice=make_from(Version.from_any_vcs)))
+        assert get_version('placeholder', third_choice=make_from(Version.from_git)) == "0.0.0"
+        assert get_version('placeholder', third_choice=make_from(Version.from_any_vcs)) == "0.0.0"

--- a/tests/unit/test_dunamai.py
+++ b/tests/unit/test_dunamai.py
@@ -1,7 +1,9 @@
 import datetime as dt
 import os
 import re
+import tempfile
 from contextlib import contextmanager
+from git import Repo
 from pathlib import Path
 from typing import Callable, Iterator, Optional
 
@@ -858,3 +860,20 @@ def test__bump_version():
 
     with pytest.raises(ValueError):
         bump_version("foo", 0)
+
+
+def test__get_version_outside_repo():
+    # TODO: Test vcs other than git
+    with tempfile.TemporaryDirectory() as dirname:
+        # Initialize a git repo
+        Repo.init(dirname)
+        # os.chdir(dirname)
+        os.chdir("/")
+
+        def make_from(func):
+            def from_other(*args, **kwargs):
+                return func(*args, path=dirname, **kwargs)
+            return from_other
+
+        print(get_version('placeholder', third_choice=make_from(Version.from_git)))
+        print(get_version('placeholder', third_choice=make_from(Version.from_any_vcs)))


### PR DESCRIPTION
This PR adds support for using the `Version.from_*` functions from outside the root of the VCS tree by passing a path to the root instead. This approach is designed to prevent the need to change into the directory except in cases where the VCS system of choice does not support such operations.

Closes #69 

TODO:
- [ ] Check if out of tree handling is possible for all supported VCS (I know mercurial supports it with `hg -R`)
- [ ] If not possible, determine if for some VCS we would be willing to `os.chdir` (suboptimal, would like to avoid)
- [ ] Determine how best to write tests