### PR TITLE
Resolve warnings of regex library

### DIFF
--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -878,7 +878,7 @@ class Version:
             failed = True
 
         if failed or matched_pattern is None:
-            replaced = re.sub(r"(\.post(\d+)\.dev\d+)", r".dev\2", version, 1)
+            replaced = re.sub(r"(\.post(\d+)\.dev\d+)", r".dev\2", version, count=1)
             if replaced != version:
                 alt = Version.parse(replaced, pattern)
                 if alt.base != replaced:


### PR DESCRIPTION
## Summary
This small PR resolves the Regex library deprecation warnings:
```python
/home/runner/work/dunamai/dunamai/dunamai/__init__.py:881: DeprecationWarning: 'count' is passed as positional argument
````
