### PR TITLE
fix: pass highest_tag in from_any_vcs

### DIFF
--- a/dunamai/__init__.py
+++ b/dunamai/__init__.py
@@ -2133,6 +2133,7 @@ class Version:
             pattern_prefix,
             ignore_untracked,
             commit_length,
+            highest_tag,
         )
 
     @classmethod


### PR DESCRIPTION
Hi, first of all, thanks for creating and maintaining this great library. 

I noticed there is a glitch in the latest version.  `highest_tag` option is ignored in the `from_any_vcs` class method. This is a PR to fix that issue.

Note: I checked unused argument issue with Pylint and there is nothing except this.

```bash
$ uvx pylint dunamai | grep W0613
dunamai/__init__.py:2082:8: W0613: Unused argument 'highest_tag' (unused-argument)
```